### PR TITLE
ci: add github-actions ecosystem to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,13 @@
 
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
   - package-ecosystem: "gomod"
     directory: "/" # Location of package manifests
     schedule:


### PR DESCRIPTION
Enable Dependabot to track and update SHA-pinned GitHub Actions in workflow files.