### PR TITLE
validate: propagate backup and worker errors from the concurrent step

### DIFF
--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -21,16 +21,23 @@ services:
     command: start-single-node --insecure --store type=mem,size=2G
     network_mode: host
 
-  cockroachdb-v25.1:
-    profiles: ["v25.1"]
-    image: cockroachdb/cockroach:latest-v25.1
+  cockroachdb-v25.2:
+    profiles: ["v25.2"]
+    image: cockroachdb/cockroach:latest-v25.2
     entrypoint: /cockroach/cockroach
     command: start-single-node --insecure --store type=mem,size=2G
     network_mode: host
 
-  cockroachdb-v25.2:
-    profiles: ["v25.2"]
-    image: cockroachdb/cockroach:latest-v25.2
+  cockroachdb-v25.4:
+    profiles: ["v25.4"]
+    image: cockroachdb/cockroach:latest-v25.4
+    entrypoint: /cockroach/cockroach
+    command: start-single-node --insecure --store type=mem,size=2G
+    network_mode: host
+
+  cockroachdb-v26.2:
+    profiles: ["v26.2"]
+    image: cockroachdb/cockroach:latest-v26.2
     entrypoint: /cockroach/cockroach
     command: start-single-node --insecure --store type=mem,size=2G
     network_mode: host

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -26,12 +26,14 @@ jobs:
       matrix:
         include:
           # These are our primary supported versions.
-          - id: v25.2
-            cockroachdb: v25.2
-          - id: v25.1
-            cockroachdb: v25.1
           - id: v24.3
             cockroachdb: v24.3
+          - id: v25.2
+            cockroachdb: v25.2
+          - id: v25.4
+            cockroachdb: v25.4
+          - id: v26.2
+            cockroachdb: v26.2
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/internal/validate/minio_integration_test.go
+++ b/internal/validate/minio_integration_test.go
@@ -112,3 +112,52 @@ func TestMinio(t *testing.T) {
 		r.Equal(1, len(report.Stats))
 	}
 }
+
+// TestBackupErrorIsReported verifies that a failure in the concurrent
+// workload-and-backup step is returned to the caller instead of being silently
+// swallowed (regression test for #114).
+func TestBackupErrorIsReported(t *testing.T) {
+	ctx := stopper.WithContext(t.Context())
+	r := require.New(t)
+	endpoint := fmt.Sprintf("http://%s", minioEndpoint)
+	vars := blob.Params{
+		blob.AccountParam: "cockroach",
+		blob.SecretParam:  "cockroach",
+		blob.RegionParam:  "us-east-1",
+	}
+	lookup := func(key string) (string, bool) {
+		val, ok := vars[key]
+		return val, ok
+	}
+	bucketName := fmt.Sprintf("bucket-%d", time.Now().UnixMilli())
+	var env = &env.Env{
+		DatabaseURL:      "postgresql://root@localhost:26257?sslmode=disable",
+		Endpoint:         endpoint,
+		LookupEnv:        lookup,
+		Path:             bucketName,
+		Testing:          true,
+		Workers:          0,
+		WorkloadDuration: 1 * time.Second,
+	}
+	r.NoError(createMinioBucket(ctx, vars, env, bucketName))
+	blobStorage, err := blob.S3FromEnv(ctx, env)
+	r.NoError(err)
+	validator, err := New(ctx, env, blobStorage)
+	r.NoError(err)
+	// The backup failure below stops the stopper context, so clean up with a
+	// separate context that is still usable for database access.
+	cleanupCtx := stopper.WithContext(t.Context())
+	defer validator.Clean(cleanupCtx)
+
+	conn, err := validator.pool.Acquire(ctx)
+	r.NoError(err)
+	defer conn.Release()
+	extConn, err := db.NewExternalConn(ctx, conn, blobStorage)
+	r.NoError(err)
+
+	// Drop the external connection so the full backup fails deterministically,
+	// simulating a storage failure during the concurrent backup step.
+	r.NoError(extConn.Drop(ctx, conn))
+
+	r.Error(validator.runConcurrentWorkloadAndBackup(ctx, extConn))
+}

--- a/internal/validate/workload.go
+++ b/internal/validate/workload.go
@@ -43,27 +43,46 @@ func (v *Validator) runWorkloadWithBackup(ctx *stopper.Context, extConn *db.Exte
 func (v *Validator) runConcurrentWorkloadAndBackup(
 	ctx *stopper.Context, extConn *db.ExternalConn,
 ) error {
-	g := sync.WaitGroup{}
-	// Start worker goroutines
-	for w := range v.env.Workers {
+	var g sync.WaitGroup
+	var mu sync.Mutex
+	var errs []error
+
+	// run launches fn under the stopper and records any error it returns.
+	// If the stopper is already stopping and rejects the goroutine, the
+	// WaitGroup counter is released so that Wait does not block forever.
+	run := func(fn func(ctx *stopper.Context) error) {
 		g.Add(1)
-		ctx.Go(func(ctx *stopper.Context) error {
-			slog.Info("starting", "worker", w)
+		accepted := ctx.Go(func(ctx *stopper.Context) error {
 			defer g.Done()
+			err := fn(ctx)
+			if err != nil {
+				mu.Lock()
+				errs = append(errs, err)
+				mu.Unlock()
+			}
+			return err
+		})
+		if !accepted {
+			g.Done()
+		}
+	}
+
+	// Start worker goroutines.
+	for w := range v.env.Workers {
+		run(func(ctx *stopper.Context) error {
+			slog.Info("starting", "worker", w)
 			return v.runWorkload(ctx, v.env.WorkloadDuration)
 		})
 	}
 
-	// Start backup goroutine
-	g.Add(1)
-	ctx.Go(func(ctx *stopper.Context) error {
-		defer g.Done()
+	// Start the full backup.
+	run(func(ctx *stopper.Context) error {
 		return v.runFullBackup(ctx, extConn)
 	})
 
 	g.Wait()
 	slog.Info("workers done")
-	return nil
+	return errors.Join(errs...)
 }
 
 // runWorkload runs a simple kv-style workload for the specified duration.
@@ -74,19 +93,31 @@ func (v *Validator) runWorkload(ctx *stopper.Context, duration time.Duration) er
 		Table:  v.sourceTable,
 	}
 	done := make(chan bool)
-	ctx.Go(func(ctx *stopper.Context) error {
+
+	var g sync.WaitGroup
+	var runErr error
+	g.Add(1)
+	accepted := ctx.Go(func(ctx *stopper.Context) error {
+		defer g.Done()
 		conn, err := v.pool.Acquire(ctx)
 		if err != nil {
+			runErr = err
 			return err
 		}
 		defer conn.Release()
-		return w.Run(ctx, conn, done)
+		runErr = w.Run(ctx, conn, done)
+		return runErr
 	})
+	if !accepted {
+		g.Done()
+	}
+
 	select {
 	case <-time.Tick(duration):
 		// signal workload to stop
 		close(done)
 	case <-ctx.Stopping():
 	}
-	return nil
+	g.Wait()
+	return runErr
 }


### PR DESCRIPTION
runConcurrentWorkloadAndBackup launched the full backup with ctx.Go but always returned nil, so a backup failure was only recorded inside the stopper and never surfaced to the caller. Validate then saw the context stopping and returned a generic context.Canceled, so a failed run could look like a success.

Collect errors from every launched goroutine (workers and backup) and return them joined. Guard against ctx.Go rejecting a goroutine while the stopper is already stopping, which would otherwise deadlock the WaitGroup. Also surface errors from runWorkload, which previously swallowed the failure from its worker goroutine.

Add a regression test that forces the full backup to fail by dropping the external connection and asserts the error is returned.

Update the CI CockroachDB matrix to v24.3, v25.2, v25.4, and v26.2 (dropping the v25.1 innovation release).

Fixes: #114