### PR TITLE
ci: upgrade GitHub Actions to latest releases (SHA-pinned)

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -37,21 +37,21 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - name: Login to ghcr.io
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -63,7 +63,7 @@ jobs:
             org.opencontainers.image.vendor=Cockroach Labs Inc.
             org.opencontainers.image.descripton=Prototype, not officially supported
       - name: Build and push
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -21,11 +21,11 @@ jobs:
   go-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - id: setup_go
         name: Set up Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: 'go.mod'
 
@@ -42,19 +42,19 @@ jobs:
         run: GOOS=darwin GOARCH=arm64 go build -o blobcheck-darwin-arm64 .
 
       - name: Upload artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: blobcheck-linux-amd64
           path: blobcheck-linux-amd64
 
       - name: Upload artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: blobcheck-linux-arm64
           path: blobcheck-linux-arm64
 
       - name: Upload artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: blobcheck-darwin-arm64
           path: blobcheck-darwin-arm64

--- a/.github/workflows/go-lint.yaml
+++ b/.github/workflows/go-lint.yaml
@@ -21,11 +21,11 @@ jobs:
   go-lints:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - id: setup_go
         name: Set up Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: 'go.mod'
 

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -36,7 +36,7 @@ jobs:
             cockroachdb: v26.2
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - id: start_services
         name: start services
@@ -45,7 +45,7 @@ jobs:
 
       - id: setup_go
         name: Set up Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: 'go.mod'
 


### PR DESCRIPTION
## Summary

Bumps each GitHub Action to the latest release within its current major version, keeping full commit SHA pins with version comments.

| Action | From | To |
|---|---|---|
| actions/checkout | v6.0.2 | v6.0.3 |
| actions/setup-go | v6.3.0 | v6.5.0 |
| actions/upload-artifact | v7.0.0 | v7.0.1 |
| docker/setup-qemu-action | v4.0.0 | v4.2.0 |
| docker/setup-buildx-action | v4.0.0 | v4.1.0 |
| docker/login-action | v4.0.0 | v4.2.0 |
| docker/metadata-action | v6.0.0 | v6.1.0 |
| docker/build-push-action | v7.0.0 | v7.3.0 |

## Notes

- `actions/checkout` is intentionally held at v6 (v7.0.0 exists but is a major bump, deferred).
- `actions/download-artifact` was already on the latest (v8.0.1), so no change.
- All pins verified with `pinact run --verify`.
- Supersedes the open Dependabot action-bump PRs (#70, #78, #95, #96, #97), which will go stale once this merges.
