### PR TITLE
validate: presplit, scatter, and seed source table before backup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/cockroachlabs-field/blobcheck
 go 1.26.4
 
 require (
+	github.com/cockroachdb/cockroach-go/v2 v2.4.3
 	github.com/cockroachdb/crlfmt v0.5.2
 	github.com/google/addlicense v1.2.0
 	github.com/jackc/pgx/v5 v5.10.0
@@ -37,12 +38,14 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/getsentry/sentry-go v0.46.0 // indirect
+	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.11 // indirect
 	github.com/klauspost/crc32 v1.3.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/lib/pq v1.10.9 // indirect
 	github.com/mattn/go-runewidth v0.0.23 // indirect
 	github.com/minio/crc64nvme v1.1.1 // indirect
 	github.com/minio/md5-simd v1.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
+github.com/cockroachdb/cockroach-go/v2 v2.4.3 h1:LJO3K3jC5WXvMePRQSJE1NsIGoFGcEx1LW83W6RAlhw=
+github.com/cockroachdb/cockroach-go/v2 v2.4.3/go.mod h1:9U179XbCx4qFWtNhc7BiWLPfuyMVQ7qdAhfrwLz1vH0=
 github.com/cockroachdb/crlfmt v0.5.2 h1:oRU4j0tuuIuW1rfdAMY1TDW4K++86aVHwxq2h9C9ZHw=
 github.com/cockroachdb/crlfmt v0.5.2/go.mod h1:fJ2Lp/cS/s84A7pvsuhtflmYJnz8JnxnjyIt5ZCigbo=
 github.com/cockroachdb/errors v1.14.0 h1:EfdVEJpN3z8rPMo43Yit59LxoiIa470fSXpZXuEs+ZI=
@@ -63,6 +65,8 @@ github.com/getsentry/sentry-go v0.46.0 h1:mbdDaarbUdOt9X+dx6kDdntkShLEX3/+KyOsVD
 github.com/getsentry/sentry-go v0.46.0/go.mod h1:evVbw2qotNUdYG8KxXbAdjOQWWvWIwKxpjdZZIvcIPw=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
+github.com/gofrs/flock v0.13.0 h1:95JolYOvGMqeH31+FC7D2+uULf6mG61mEZ/A8dRYMzw=
+github.com/gofrs/flock v0.13.0/go.mod h1:jxeyy9R1auM5S6JYDBhDt+E2TCo7DkratH4Pgi8P+Z0=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/google/addlicense v1.2.0 h1:W+DP4A639JGkcwBGMDvjSurZHvaq2FN0pP7se9czsKA=
@@ -96,6 +100,8 @@ github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/mattn/go-runewidth v0.0.23 h1:7ykA0T0jkPpzSvMS5i9uoNn2Xy3R383f9HDx3RybWcw=
 github.com/mattn/go-runewidth v0.0.23/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/minio/crc64nvme v1.1.1 h1:8dwx/Pz49suywbO+auHCBpCtlW1OfpcLN7wYgVR6wAI=

--- a/internal/db/integration_test.go
+++ b/internal/db/integration_test.go
@@ -24,6 +24,31 @@ import (
 	"github.com/cockroachdb/field-eng-powertools/stopper"
 )
 
+// TestPresplitSingleNode verifies Split, Scatter, and LeaseholderCount on a single-node cluster.
+func TestPresplitSingleNode(t *testing.T) {
+	a := assert.New(t)
+	r := require.New(t)
+	ctx := stopper.WithContext(t.Context())
+	testEnv, err := NewTestEnv(ctx, 0)
+	r.NoError(err)
+	defer func() { a.NoError(testEnv.Cleanup(ctx)) }()
+	conn, err := testEnv.Pool.Acquire(ctx)
+	r.NoError(err)
+	defer conn.Release()
+
+	r.NoError(testEnv.KvTable.PresplitAndScatter(ctx, conn, 8))
+
+	var count int
+	r.NoError(conn.QueryRow(ctx,
+		fmt.Sprintf("SELECT count(*) FROM [SHOW RANGES FROM TABLE %s]", testEnv.KvTable.String()),
+	).Scan(&count))
+	a.GreaterOrEqual(count, 8, "expected at least 8 ranges after SPLIT AT")
+
+	leaseholders, err := testEnv.KvTable.LeaseholderCount(ctx, conn)
+	r.NoError(err)
+	a.Equal(1, leaseholders, "single-node cluster should have exactly 1 leaseholder")
+}
+
 // TestIntegration runs a tests to insure we can create database, table and external connection.
 // It tests the end-to-end functionality of the database layer.
 func TestIntegration(t *testing.T) {

--- a/internal/db/kvtable.go
+++ b/internal/db/kvtable.go
@@ -102,6 +102,104 @@ func (t *KvTable) LocalName() string {
 	return strings.Join([]string{t.Schema.String(), string(t.Name)}, ".")
 }
 
+// hexSplitPoints returns ranges-1 evenly spaced hex-prefix boundaries that
+// divide the gen_random_uuid() keyspace into `ranges` roughly equal parts.
+// Returns nil when ranges < 2. Boundaries are 4 hex digits wide, giving 65536
+// distinct buckets, which is ample for any realistic node count.
+func hexSplitPoints(ranges int) []string {
+	if ranges < 2 {
+		return nil
+	}
+	const buckets = 0x10000
+	points := make([]string, 0, ranges-1)
+	for i := 1; i < ranges; i++ {
+		points = append(points, fmt.Sprintf("%04x", i*buckets/ranges))
+	}
+	return points
+}
+
+const splitTableStmt = `ALTER TABLE %[1]s SPLIT AT VALUES %[2]s`
+
+// Split presplits the table at the given primary-key boundaries.
+func (t *KvTable) Split(ctx *stopper.Context, conn *pgxpool.Conn, points []string) error {
+	if len(points) == 0 {
+		return nil
+	}
+	slog.Debug("splitting table", slog.String("table", t.String()), slog.Any("split_points", points))
+	quoted := make([]string, len(points))
+	for i, p := range points {
+		quoted[i] = fmt.Sprintf("('%s')", p)
+	}
+	stmt := fmt.Sprintf(splitTableStmt, t.String(), strings.Join(quoted, ", "))
+	_, err := conn.Exec(ctx, stmt)
+	return err
+}
+
+const scatterTableStmt = `ALTER TABLE %[1]s SCATTER`
+
+// Scatter distributes the table's ranges across the cluster nodes.
+func (t *KvTable) Scatter(ctx *stopper.Context, conn *pgxpool.Conn) error {
+	_, err := conn.Exec(ctx, fmt.Sprintf(scatterTableStmt, t.String()))
+	return err
+}
+
+// PresplitAndScatter presplits the table into `ranges` ranges and scatters
+// them across the cluster so that backup is more likely to exercise every node.
+func (t *KvTable) PresplitAndScatter(ctx *stopper.Context, conn *pgxpool.Conn, ranges int) error {
+	if err := t.Split(ctx, conn, hexSplitPoints(ranges)); err != nil {
+		return err
+	}
+	return t.Scatter(ctx, conn)
+}
+
+// hexSeedKeys returns one seed key per range, each positioned just above the
+// range's lower boundary. Seeding gives scattered ranges data to export so
+// backup is more likely to contact every node. The first range uses prefix
+// "0000"; subsequent ranges use the corresponding split boundary from
+// hexSplitPoints. Returns nil when ranges < 1.
+func hexSeedKeys(ranges int) []string {
+	if ranges < 1 {
+		return nil
+	}
+	points := hexSplitPoints(ranges) // len == ranges-1
+	prefixes := make([]string, ranges)
+	prefixes[0] = "0000"
+	for i, p := range points {
+		prefixes[i+1] = p
+	}
+	keys := make([]string, ranges)
+	for i, pfx := range prefixes {
+		// Construct a UUID-shaped string whose leading 4 hex chars match the
+		// range prefix so lexicographic ordering places it in the right range.
+		keys[i] = pfx + "0000-0000-0000-0000-000000000001"
+	}
+	return keys
+}
+
+// SeedRanges inserts one deterministic row per range so that scattered ranges
+// have data to export during backup. Call after PresplitAndScatter.
+func (t *KvTable) SeedRanges(ctx *stopper.Context, conn *pgxpool.Conn, ranges int) error {
+	for _, k := range hexSeedKeys(ranges) {
+		if err := t.Upsert(ctx, conn, k, "seed"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+const leaseholderCountStmt = `SELECT count(DISTINCT lease_holder) FROM [SHOW RANGES FROM TABLE %[1]s WITH DETAILS]`
+
+// LeaseholderCount returns the number of distinct nodes currently holding
+// leases for the table's ranges. Used to observe how SCATTER distributed the
+// ranges before a backup.
+func (t *KvTable) LeaseholderCount(ctx *stopper.Context, conn *pgxpool.Conn) (int, error) {
+	var n int
+	if err := conn.QueryRow(ctx, fmt.Sprintf(leaseholderCountStmt, t.String())).Scan(&n); err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
 const fingerprintStmt = `SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE %s`
 
 // Fingerprint returns a fingerprint for the table.

--- a/internal/db/kvtable_test.go
+++ b/internal/db/kvtable_test.go
@@ -1,0 +1,74 @@
+// Copyright 2025 Cockroach Labs, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package db
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHexSeedKeys(t *testing.T) {
+	a := assert.New(t)
+
+	a.Nil(hexSeedKeys(0), "0 ranges should return nil")
+
+	one := hexSeedKeys(1)
+	require.Len(t, one, 1)
+	a.Equal("00000000-0000-0000-0000-000000000001", one[0])
+
+	keys := hexSeedKeys(4)
+	require.Len(t, keys, 4, "4 ranges should yield 4 seed keys")
+	a.Equal("00000000-0000-0000-0000-000000000001", keys[0])
+	a.Equal("40000000-0000-0000-0000-000000000001", keys[1])
+	a.Equal("80000000-0000-0000-0000-000000000001", keys[2])
+	a.Equal("c0000000-0000-0000-0000-000000000001", keys[3])
+
+	// Each key must sort strictly above the previous one, and each key must
+	// sort above the corresponding split boundary.
+	splitPts := hexSplitPoints(4) // ["4000", "8000", "c000"]
+	for i := 1; i < len(keys); i++ {
+		a.Greater(keys[i], keys[i-1], "seed keys must be strictly increasing")
+		a.GreaterOrEqual(keys[i], splitPts[i-1], "seed key[%d] must be >= split point[%d]", i, i-1)
+	}
+	// First key must fall below the first split boundary.
+	a.Less(keys[0], splitPts[0], "first seed key must be below first split boundary")
+}
+
+func TestHexSplitPoints(t *testing.T) {
+	a := assert.New(t)
+
+	a.Nil(hexSplitPoints(0), "0 ranges should return nil")
+	a.Nil(hexSplitPoints(1), "1 range should return nil")
+
+	pts := hexSplitPoints(4)
+	require.Len(t, pts, 3, "4 ranges should yield 3 boundaries")
+	a.Equal([]string{"4000", "8000", "c000"}, pts)
+
+	for _, p := range pts {
+		a.Regexp(`^[0-9a-f]{4}$`, p, "boundary must be 4 lowercase hex chars")
+	}
+
+	large := hexSplitPoints(300)
+	require.Len(t, large, 299)
+	a.True(sort.StringsAreSorted(large), "boundaries must be sorted")
+	seen := make(map[string]bool, len(large))
+	for _, p := range large {
+		a.False(seen[p], "duplicate boundary: %s", p)
+		seen[p] = true
+	}
+}

--- a/internal/db/presplit_integration_test.go
+++ b/internal/db/presplit_integration_test.go
@@ -1,0 +1,79 @@
+// Copyright 2025 Cockroach Labs, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cockroachdb/cockroach-go/v2/testserver"
+	"github.com/cockroachdb/field-eng-powertools/stopper"
+)
+
+// TestPresplitMultiNode starts a real 3-node cluster using cockroach-go testserver,
+// presplits a table, and asserts that SCATTER distributes leases across more than one node.
+func TestPresplitMultiNode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping multi-node test in short mode")
+	}
+
+	ts, err := testserver.NewTestServer(testserver.ThreeNodeOpt())
+	require.NoError(t, err)
+	defer ts.Stop()
+	// WaitForInit only waits for node 0; wait for all three before proceeding.
+	for i := range 3 {
+		require.NoError(t, ts.WaitForInitFinishForNode(i))
+	}
+
+	a := assert.New(t)
+	r := require.New(t)
+
+	ctx := stopper.WithContext(t.Context())
+	pool, err := pgxpool.New(ctx, ts.PGURL().String())
+	r.NoError(err)
+	defer pool.Close()
+
+	conn, err := pool.Acquire(ctx)
+	r.NoError(err)
+	defer conn.Release()
+
+	db := Database{Name: "_presplit_test"}
+	r.NoError(db.Create(ctx, conn))
+	defer func() { a.NoError(db.Drop(ctx, conn)) }()
+
+	table := KvTable{
+		Database: db,
+		Schema:   Schema{"public"},
+		Name:     "tmp",
+	}
+	r.NoError(table.Create(ctx, conn))
+
+	const numRanges = 9 // 3 nodes * rangesPerNode
+	r.NoError(table.PresplitAndScatter(ctx, conn, numRanges))
+
+	// Poll until leases spread to more than one node, or timeout. We assert >= 2
+	// rather than == 3 because older CRDB versions balance leases more slowly and
+	// may not reach full distribution within a reasonable CI timeout. Getting > 1
+	// is sufficient to confirm that SCATTER moved leases off a single node.
+	r.Eventually(func() bool {
+		leaseholders, err := table.LeaseholderCount(ctx, conn)
+		return err == nil && leaseholders >= 2
+	}, 2*time.Minute, 500*time.Millisecond,
+		"SCATTER should distribute leases to more than one node")
+}

--- a/internal/validate/db.go
+++ b/internal/validate/db.go
@@ -58,7 +58,6 @@ func createSourceTable(ctx *stopper.Context, conn *pgxpool.Conn) (db.KvTable, er
 		return db.KvTable{}, errors.Wrap(err, "failed to create source database")
 	}
 
-	// TODO (silvano): presplit table to have ranges in all nodes
 	sourceTable := db.KvTable{
 		Database: source,
 		Schema:   db.Public,

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -17,6 +17,7 @@ package validate
 
 import (
 	"log/slog"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -32,6 +33,9 @@ const (
 	expectedBackupCount       = 2
 	expectedBackupCollections = 1
 	expectedFullBackupCount   = 1
+
+	rangesPerNode = 3  // over-split so SCATTER lands a leaseholder on every node
+	defaultRanges = 16 // fallback when node count is unknown (CRDB < v25.1)
 )
 
 // Report contains the results of a validation run.
@@ -181,6 +185,12 @@ func (v *Validator) Validate(ctx *stopper.Context) (*Report, error) {
 			},
 		},
 		{
+			name: "presplit source table",
+			fn: func(ctx *stopper.Context, extConn *db.ExternalConn) error {
+				return v.presplitSourceTable(ctx, len(stats))
+			},
+		},
+		{
 			name: "workload with backup",
 			fn:   v.runWorkloadWithBackup,
 		},
@@ -223,4 +233,59 @@ func (v *Validator) Validate(ctx *stopper.Context) (*Report, error) {
 		SuggestedParams: extConn.SuggestedParams(),
 		Stats:           stats,
 	}, nil
+}
+
+// presplitSourceTable splits the source table into ranges and scatters them so
+// the backup exercises every node's connectivity to the object store. nodes is
+// the node count observed from the initial stats; 0 means it is unknown.
+func (v *Validator) presplitSourceTable(ctx *stopper.Context, nodes int) error {
+	if nodes == 1 {
+		// Single node: nothing to spread.
+		return nil
+	}
+	ranges := defaultRanges
+	if nodes > 1 {
+		ranges = nodes * rangesPerNode
+	}
+	conn, err := v.acquireConn(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Release()
+	slog.Info("presplitting and scattering source table",
+		slog.Int("nodes", nodes), slog.Int("ranges", ranges))
+	if err := v.sourceTable.PresplitAndScatter(ctx, conn, ranges); err != nil {
+		return err
+	}
+	// Wait up to one minute for leases to spread across nodes after SCATTER.
+	// Lease settling is best-effort: we log the result at Info and continue
+	// regardless of how many nodes were reached.
+	var leaseholders int
+	if nodes > 1 {
+		deadline := time.Now().Add(time.Minute)
+		for time.Now().Before(deadline) {
+			leaseholders, err = v.sourceTable.LeaseholderCount(ctx, conn)
+			if err != nil || leaseholders >= nodes {
+				break
+			}
+			select {
+			case <-time.After(500 * time.Millisecond):
+			case <-ctx.Stopping():
+				return nil
+			}
+		}
+	}
+	if err != nil {
+		slog.Debug("failed to read leaseholder distribution", slog.Any("error", err))
+	} else {
+		slog.Info("source table leaseholder distribution",
+			slog.Int("distinct_leaseholders", leaseholders), slog.Int("nodes", nodes))
+	}
+	// Seed one row per range so that scattered ranges have data to export during
+	// backup, making it more likely that every node's storage path is exercised.
+	slog.Debug("seeding source table ranges", slog.Int("ranges", ranges))
+	if err := v.sourceTable.SeedRanges(ctx, conn, ranges); err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/validate/workload.go
+++ b/internal/validate/workload.go
@@ -87,7 +87,6 @@ func (v *Validator) runConcurrentWorkloadAndBackup(
 
 // runWorkload runs a simple kv-style workload for the specified duration.
 func (v *Validator) runWorkload(ctx *stopper.Context, duration time.Duration) error {
-	// TODO (silvano): if table is presplit, use prefix according to the split
 	w := workload.Workload{
 		Prefix: uuid.New().String(),
 		Table:  v.sourceTable,


### PR DESCRIPTION
## Summary

- After capturing initial stats, split the source table into ranges based on observed node count (`nodes * 3`, defaulting to 16 for clusters older than v25.1), scatter them across the cluster, and insert one deterministic seed row per range.
- Every node now holds a leaseholder range with data to export before the backup runs, so a storage connectivity failure on any node surfaces as a backup failure rather than going undetected.
- The concurrent workload remains random; deterministic coverage is handled by the new seed step.

## Changes

- `internal/db/kvtable.go`: adds `hexSplitPoints`, `hexSeedKeys`, `Split`, `Scatter`, `PresplitAndScatter`, `SeedRanges`, `LeaseholderCount`
- `internal/validate/validate.go`: adds `presplitSourceTable` called as a step after "capture initial stats"
- `internal/validate/db.go`: removes stale presplit TODO
- `internal/validate/workload.go`: removes stale prefix-alignment TODO
- `internal/db/kvtable_test.go`: unit tests for `hexSplitPoints` and `hexSeedKeys` (no cluster required)
- `internal/db/integration_test.go`: single-node presplit/scatter/leaseholder-count assertions
- `internal/db/presplit_integration_test.go`: three-node test via `cockroach-go/v2/testserver`, polls until leases spread across all nodes; skipped under `-short`
- `go.mod`/`go.sum`: adds `github.com/cockroachdb/cockroach-go/v2 v2.4.3`

Fixes #115.