### PR TITLE
ci: bump GitHub Actions (checkout v7, docker actions)

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -37,21 +37,21 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Login to ghcr.io
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4 # v4.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -21,7 +21,7 @@ jobs:
   go-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - id: setup_go
         name: Set up Go

--- a/.github/workflows/go-lint.yaml
+++ b/.github/workflows/go-lint.yaml
@@ -21,7 +21,7 @@ jobs:
   go-lints:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - id: setup_go
         name: Set up Go

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -36,7 +36,7 @@ jobs:
             cockroachdb: v26.2
 
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - id: start_services
         name: start services


### PR DESCRIPTION
Combines the open dependabot GitHub Actions bumps into a single change. Dependabot will close its individual PRs automatically once these SHAs land on main.

## Changes

- `actions/checkout` 6.0.3 -> 7.0.0 (#121)
- `docker/setup-buildx-action` 4.1.0 -> 4.2.0 (#122)
- `docker/login-action` 4.2.0 -> 4.3.0 (#123)
- `docker/metadata-action` 6.1.0 -> 6.2.0 (#124)

All actions remain pinned to full commit SHAs, matching the values dependabot resolved. pinact validated the SHA/comment pairings.